### PR TITLE
Potential fix for code scanning alert no. 2: Use of externally-controlled format string

### DIFF
--- a/src/api/nhl.js
+++ b/src/api/nhl.js
@@ -332,7 +332,7 @@ export const getTeamStats = async (teamId) => {
       
       return response.data;
     } catch (error) {
-      console.log(`Failed ${endpoint}:`, error.response?.status, error.message);
+      console.log('Failed %s: %s %s', endpoint, error.response?.status, error.message);
     }
   }
   


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/statsjam/security/code-scanning/2](https://github.com/djleamen/statsjam/security/code-scanning/2)

To fix the issue, the format string in the `console.log` statement on line 335 should be modified to use a `%s` specifier for the `endpoint` variable. This ensures that the `endpoint` is treated as a string and prevents any unintended interpretation of format specifiers. Additionally, the `error.response?.status` and `error.message` should be passed as separate arguments to avoid concatenation issues.

**Steps to implement the fix:**
1. Update the `console.log` statement on line 335 to use a format string with `%s` for the `endpoint`.
2. Pass the `endpoint`, `error.response?.status`, and `error.message` as separate arguments to the `console.log` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
