### PR TITLE
Potential fix for code scanning alert no. 1: Use of externally-controlled format string

### DIFF
--- a/src/api/nhl.js
+++ b/src/api/nhl.js
@@ -316,7 +316,7 @@ export const getTeamStats = async (teamId) => {
     try {
       console.log(`Trying endpoint: ${endpoint}`);
       const response = await api.get(endpoint);
-      console.log(`SUCCESS! Response from ${endpoint}:`, response.data);
+      console.log('SUCCESS! Response from %s:', endpoint, response.data);
       
       // If it's standings data, extract the team's stats
       if (endpoint.includes('standings')) {


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/statsjam/security/code-scanning/1](https://github.com/djleamen/statsjam/security/code-scanning/1)

To fix the issue, the format string in the `console.log` statement on line 319 should be updated to use explicit `%s` specifiers. This ensures that the `endpoint` variable is treated as a string and avoids unintended behavior caused by format specifiers in the interpolated value.

#### Steps to fix:
1. Replace the interpolated format string `` `SUCCESS! Response from ${endpoint}:` `` with a format string that uses `%s` specifiers.
2. Pass the `endpoint` variable as an argument to `console.log` to match the `%s` specifier.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
