### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/statsjam/security/code-scanning/3](https://github.com/djleamen/statsjam/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to read repository contents (for checkout and running tests), set `permissions: contents: read` at the workflow level (top-level, just after the `name` or `on` block). This ensures all jobs in the workflow inherit these minimal permissions unless overridden. No changes to the jobs or steps are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
