### PR TITLE
Fix npm ci failure and guard against missing teams data

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/src/api/nhl.js
+++ b/src/api/nhl.js
@@ -130,14 +130,17 @@ export const getTeams = async () => {
     const response = await api.get('/league/teams.json');
     console.log('✅ API Response received:', response.status);
     console.log('🔍 Raw teams data:', response.data.teams);
-    
+
+    // Guard against unexpected response shapes (e.g. missing teams array)
+    const teams = Array.isArray(response.data?.teams) ? response.data.teams : [];
+
     // Log team structure to understand the data
-    if (response.data.teams && response.data.teams.length > 0) {
-      console.log('📊 Sample team structure:', response.data.teams[0]);
+    if (teams.length > 0) {
+      console.log('📊 Sample team structure:', teams[0]);
     }
-    
+
     // Filter out non-NHL teams based on known patterns
-    const nhlTeams = response.data.teams.filter(team => {
+    const nhlTeams = teams.filter(team => {
       // Filter out national teams
       const nationalTeams = ['Team Canada', 'Team Finland', 'Team Sweden', 'Team USA', 'Team Czech Republic'];
       if (nationalTeams.includes(`${team.market} ${team.name}`) || 


### PR DESCRIPTION
## Testing summary

- `npm ci` initially **failed** with an ERESOLVE peer-dependency conflict: `eslint@10.0.1` vs `eslint-plugin-react-hooks@5.2.0` (peer range only allows eslint up to 9). This also breaks the Node.js CI workflow, which runs plain `npm ci`.
- After the fix: `npm ci`, `npm run lint` (0 problems) and `npm run build` (vite, 11.7k modules) all pass.
- Dev server smoke test: `vite` on port 5181 returns HTTP 200 and serves the app shell.
- Edge-case review of `src/api/nhl.js`: `getTeams` dereferenced `response.data.teams.filter(...)` directly, so a 200 response without a `teams` array would throw an unhandled TypeError instead of falling back gracefully. Player stat helpers (`getSavePercentage`, etc.) were checked and already guard against missing/zero values.

## Fixes

- Add `.npmrc` with `legacy-peer-deps=true` so `npm ci`/`npm install` succeed locally and in CI without changing any dependency versions.
- Guard `getTeams` against API responses without a `teams` array.

https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5)_