### PR TITLE
fix(api): stop leaking Sportradar api_key in console error logs

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
+        # Node 18 dropped: vite@8 requires Node 20.19+ / 22.12+.
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/src/api/nhl.js
+++ b/src/api/nhl.js
@@ -199,11 +199,13 @@ export const getTeams = async () => {
     return mappedTeams;
     
   } catch (error) {
+    // Log only safe fields. error.config/request/response carry the request
+    // params (including api_key), so dumping them would leak the key to the
+    // browser console.
     console.error('❌ API Error Details:', {
       message: error.message,
-      response: error.response,
-      request: error.request,
-      config: error.config
+      status: error.response?.status,
+      code: error.code
     });
     
     // Check if it's a network error and we're in development


### PR DESCRIPTION
## Summary

Two focused fixes:

### 1. Stop leaking the Sportradar `api_key` in console error logs (`src/api/nhl.js`)

The `getTeams` catch block logged the full axios error object fields to the console:

```js
console.error('❌ API Error Details:', {
  message: error.message,
  response: error.response,
  request: error.request,
  config: error.config   // <-- contains params: { api_key: API_KEY }
});
```

Axios's `error.config` carries the request configuration, including `params: { api_key: API_KEY }`. So on **any** failed `getTeams` request, the Sportradar API key was printed to the browser console (and `error.response`/`error.request` can echo it back too). Now it logs only safe fields — `message`, `status`, `code` — matching the existing response interceptor and the other catch blocks in the same file.

This does not address #34 (the key being inlined into the production bundle), which is architectural and tracked separately. It only closes the console-leak path.

### 2. Drop Node 18 from the CI build matrix (`.github/workflows/node.js.yml`)

`vite@8` requires Node 20.19+ / 22.12+, so the `build (18.x)` matrix job was failing on **every** run (`ReferenceError: CustomEvent is not defined`) — this was already red on `main` before this PR. Removed `18.x`, leaving `20.x` and `22.x`, which the toolchain actually supports.

## Testing

- `npx eslint src/api/nhl.js` — clean
- `npm run build` — succeeds (local Node 22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)