### PR TITLE
fix(dev-proxy): stop logging Sportradar api_key in request URL

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -14,10 +14,10 @@ export default defineConfig({
             console.log('proxy error', err);
           });
           proxy.on('proxyReq', (proxyReq, req) => {
-            console.log('Sending Request to the Target:', req.method, req.url);
+            console.log('Sending Request to the Target:', req.method, req.url.split('?')[0]);
           });
           proxy.on('proxyRes', (proxyRes, req) => {
-            console.log('Received Response from the Target:', proxyRes.statusCode, req.url);
+            console.log('Received Response from the Target:', proxyRes.statusCode, req.url.split('?')[0]);
           });
         },
       }


### PR DESCRIPTION
## Summary

The Vite dev-server proxy `configure` handler logged the full request URL on every dev request. That URL carries the `?api_key=...` Sportradar query string, so the API key was printed to the console for every proxied request. This is the same class of key leak fixed in PR #38 (which stopped dumping `error.config`), missed in this file.

## Changes

- `vite.config.js`: strip the query string before logging in both proxy log lines (`proxyReq` and `proxyRes`) by logging `req.url.split('?')[0]`. The HTTP method and response status are still logged.

## Testing

- `node --check vite.config.js` passes.
- Grepped the file to confirm no remaining log line prints a URL that includes the query string.

Note: issue #34's client-bundle key exposure is architectural and intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193FofFePJp2CBnHfwMwXv9

---
_Generated by [Claude Code](https://claude.ai/code/session_0193FofFePJp2CBnHfwMwXv9)_