### PR TITLE
fix(player): compute player age from full birthdate, not just year

### DIFF
--- a/src/pages/Player.jsx
+++ b/src/pages/Player.jsx
@@ -109,7 +109,14 @@ function Player() {
   // Helper render functions to reduce complexity and avoid nested ternaries
   const getPlayerAge = (birthdate) => {
     if (!birthdate) return 0;
-    return new Date().getFullYear() - new Date(birthdate).getFullYear();
+    const today = new Date();
+    const birth = new Date(birthdate);
+    let age = today.getFullYear() - birth.getFullYear();
+    const monthDiff = today.getMonth() - birth.getMonth();
+    if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+      age--;
+    }
+    return age;
   };
 
   const getPlusMinus = (pm) => {


### PR DESCRIPTION
## Summary

`getPlayerAge` in `src/pages/Player.jsx` computed age from the year difference alone:

```js
return new Date().getFullYear() - new Date(birthdate).getFullYear();
```

This **overstates age by one** for any player whose birthday hasn't occurred yet in the current year — a visible inaccuracy on the player info table.

## Fix

Decrement the computed age when today falls before the birth month/day (standard age calculation):

```js
const monthDiff = today.getMonth() - birth.getMonth();
if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
  age--;
}
```

## Testing
- `eslint src/pages/Player.jsx` → clean.
- `npm run build` → built successfully.

(The repo's `test` script is a no-op placeholder, so there's no unit-test harness to extend.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfqQPWkTooa6Hp62mnU518)_